### PR TITLE
Simplify urls setup with positive-lookahead.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+- **Breaking change**: Simplify urls setup.
+  In ``urls.py``, change cartridge_braintree urls to
+  ``url("^shop/(?=checkout(/?)$)", include("cartridge_braintree.urls")),``.
+
 1.0b17 (2016-04-17)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -79,14 +79,12 @@ Instructions for use
    for Braintree's tutorial.
 
 6. Include ``cartridge_braintree.urls`` for ``shop/checkout`` in ``urls.py``
-   before Cartridge urls and define the ``_slash`` variable::
-
-      _slash = "/" if settings.APPEND_SLASH else ""
+   before Cartridge urls::
 
       urlpatterns += [
 
           # cartridge_braintree URLs.
-          url("^shop/checkout%s" % _slash, include("cartridge_braintree.urls")),
+          url("^shop/(?=checkout(/?)$)", include("cartridge_braintree.urls")),
 
           # Cartridge URLs.
           url("^shop/", include("cartridge.shop.urls")),

--- a/cartridge_braintree/urls.py
+++ b/cartridge_braintree/urls.py
@@ -2,10 +2,13 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url
 
+from mezzanine.conf import settings
 from cartridge.shop import views
 
 from cartridge_braintree import braintree_payment, forms
 
+
+_slash = "/" if settings.APPEND_SLASH else ""
 
 extra_context = {"client_token": braintree_payment.client_token()}
 extra_options = {
@@ -14,5 +17,8 @@ extra_options = {
 }
 
 urlpatterns = [
-    url("^$", views.checkout_steps, extra_options, name="shop_checkout"),
+    url("^checkout%s$" % _slash,
+        views.checkout_steps,
+        extra_options,
+        name="shop_checkout"),
 ]


### PR DESCRIPTION
Note that the lookahead goes to the end of the string (`$`) to avoid
matching `/checkout/<subpage>`.
